### PR TITLE
Narrow the [bot] authorization bypass to the app's own bot

### DIFF
--- a/src/app.js
+++ b/src/app.js
@@ -8,8 +8,26 @@ const emergencyLabel = process.env.EMERGENCY_LABEL || 'emergency';
  */
 module.exports = (app) => {
   //context.log("Yay! The app was loaded!");
+
+  // Resolve this app's own bot login once per process via GitHub App self-introspection.
+  // Used by isAuthorized to allowlist exactly the app's own bot (which legitimately
+  // re-enters its own labeled event) while keeping every other bot subject to AUTHORIZED_TEAM.
+  let cachedAppBotLogin;
+  async function getAppBotLogin() {
+    if (cachedAppBotLogin !== undefined) return cachedAppBotLogin;
+    try {
+      const appOctokit = await app.auth();
+      const { data } = await appOctokit.rest.apps.getAuthenticated();
+      cachedAppBotLogin = `${data.slug}[bot]`;
+      app.log(`Detected app bot login: ${cachedAppBotLogin}`);
+    } catch (e) {
+      app.log(`Could not detect app bot login (${e.message}). The self-trigger label flow will be blocked by AUTHORIZED_TEAM.`);
+    }
+    return cachedAppBotLogin;
+  }
+
   app.on("pull_request.labeled", async (context) => {
-    let authorized = await isAuthorized(context)
+    let authorized = await isAuthorized(context, getAppBotLogin)
     if (context.payload.label.name == emergencyLabel 
         && context.payload.pull_request.merged == false  
         && authorized) {
@@ -218,7 +236,7 @@ module.exports = (app) => {
       context.log("No trigger string specified. Skipping auto-label check.");
       return;
     }
-    let authorized = await isAuthorized(context)
+    let authorized = await isAuthorized(context, getAppBotLogin)
     if (context.payload.pull_request.body.toLocaleLowerCase().includes(process.env.TRIGGER_STRING) 
         && authorized) {
 
@@ -255,7 +273,7 @@ module.exports = (app) => {
       context.log("No trigger string specified. Skipping auto-label check.");
       return;
     }
-    let authorized = await isAuthorized(context)
+    let authorized = await isAuthorized(context, getAppBotLogin)
     if (context.payload.issue.pull_request 
         && context.payload.comment.body.toLocaleLowerCase().includes(process.env.TRIGGER_STRING) 
         && authorized) {
@@ -290,7 +308,7 @@ module.exports = (app) => {
   });
 };
 
-async function isAuthorized(context) {
+async function isAuthorized(context, getAppBotLogin) {
   let login = context.payload.sender.login;
   let org = context.payload.organization.login;
   let octokit = context.octokit;
@@ -300,10 +318,14 @@ async function isAuthorized(context) {
       context.log("No authorized team specified. Skipping authorization check.")
       return true;
   }
-  // if login ends with [bot] then it's a bot and we don't need to check
+  // Only this app's own bot (which re-enters its own labeled event after applying
+  // the emergency label) may bypass. Other bots fall through to the team check.
   if (login.endsWith("[bot]")) {
-      context.log("Bot detected. Skipping authorization check.")
-      return true;
+      const appBotLogin = await getAppBotLogin();
+      if (appBotLogin && login === appBotLogin) {
+          context.log(`App bot ${login} detected. Skipping authorization check.`)
+          return true;
+      }
   }
   context.log(`Checking if ${login} is a member of ${org}/${process.env.AUTHORIZED_TEAM} team`)
   try {

--- a/test.js
+++ b/test.js
@@ -85,6 +85,44 @@ const payloadPrLabeledByBot = {
   },
 }
 
+const payloadPrLabeledByOtherBot = {
+  loadName: "payloadPrLabeled",
+  name: "pull_request",
+  id: "1",
+  payload: {
+    action: "labeled",
+    label: {
+      name: "emergency"
+    },
+    repository: {
+      owner: {
+        login: "robandpdx",
+      },
+      name: "superbigmono",
+      url: "https://api.github.com/repos/robandpdx/superbigmono"
+    },
+    pull_request: {
+      number: 1,
+      url: "https://api.github.com/repos/robandpdx/superbigmono/pulls/1",
+      html_url: "https://github.com/robandpdx/superbigmono/pull/1",
+      merged: false,
+      base: {
+        repo: {
+          allow_merge_commit: true,
+          allow_squash_merge: true,
+          allow_rebase_merge: true
+        }
+      }
+    },
+    organization: {
+      login: "robandpdx",
+    },
+    sender: {
+      login: "dependabot[bot]",
+    }
+  },
+}
+
 const payloadUnlabeled = {
   loadName: "payloadUnlabeled",
   name: "pull_request",
@@ -262,8 +300,9 @@ const payloadNonMembershipResponse = {
   "state": "inactive"
 }
 
-// Ensure EMERGENCY_LABEL is unset at initial require so that
-// `process.env.EMERGENCY_LABEL || 'emergency'` exercises the default-fallback branch.
+// Unset EMERGENCY_LABEL before requiring ./app so the module-level
+// `process.env.EMERGENCY_LABEL || 'emergency'` fallback branch is exercised.
+// All tests use the literal 'emergency' value anyway, so behavior is unchanged.
 delete process.env.EMERGENCY_LABEL;
 const app = require("./src/app");
 
@@ -540,19 +579,119 @@ test("recieves pull_request.labeled event, check team membership, merge the PR",
   assert.equal(mock.pendingMocks(), []);
 });
 
-// This test will merge the PR because label was applied by a bot
+// This test will merge the PR because the label was applied by this app's own bot,
+// which the app self-detects via GET /app.
 test("recieves pull_request.labeled event from a bot, merge the PR", async function () {
   process.env.APPROVE_PR = 'false';
   process.env.CREATE_ISSUE = 'false';
   process.env.MERGE_PR = 'true';
   process.env.SLACK_NOTIFY = 'false';
   process.env.AUTHORIZED_TEAM = 'emergency-team'
-  
-  // mock the request to add approval to the pr
+
+  // mock the GitHub App self-introspection used to detect this app's bot login
   const mock = nock("https://api.github.com")
+    .get("/app").reply(200, { slug: "emergency-pr" })
     .put("/repos/robandpdx/superbigmono/pulls/1/merge").reply(200);
 
   await probot.receive(payloadPrLabeledByBot);
+  assert.equal(mock.pendingMocks(), []);
+});
+
+// Two bot-triggered events in the same test exercise the cached path of
+// getAppBotLogin: the first event populates cachedAppBotLogin via GET /app,
+// the second hits the `cachedAppBotLogin !== undefined` early-return branch
+// and must NOT call GET /app again.
+test("recieves pull_request.labeled event from a bot twice, second call uses cached app bot login", async function () {
+  process.env.APPROVE_PR = 'false';
+  process.env.CREATE_ISSUE = 'false';
+  process.env.MERGE_PR = 'true';
+  process.env.SLACK_NOTIFY = 'false';
+  process.env.AUTHORIZED_TEAM = 'emergency-team'
+
+  // First event: self-introspection happens once and PR is merged.
+  const mock = nock("https://api.github.com")
+    .get("/app").reply(200, { slug: "emergency-pr" })
+    .put("/repos/robandpdx/superbigmono/pulls/1/merge").reply(200);
+
+  await probot.receive(payloadPrLabeledByBot);
+  assert.equal(mock.pendingMocks(), []);
+
+  // Second event: cachedAppBotLogin is already set, so GET /app must NOT be
+  // called. Only the merge mock is registered; if the code re-introspects,
+  // nock will throw "Nock: No match for request" on GET /app.
+  const mock2 = nock("https://api.github.com")
+    .put("/repos/robandpdx/superbigmono/pulls/1/merge").reply(200);
+
+  await probot.receive(payloadPrLabeledByBot);
+  assert.equal(mock2.pendingMocks(), []);
+});
+
+// This test will not merge the PR because the sender is a bot but not this app's
+// own bot. External bots cannot be allowlisted (GitHub teams cannot contain bot
+// identities), so the team-membership check returns 404 and the bot is rejected.
+test("recieves pull_request.labeled event from a non-app bot, do not merge the PR", async function () {
+  process.env.APPROVE_PR = 'false';
+  process.env.CREATE_ISSUE = 'false';
+  process.env.MERGE_PR = 'true';
+  process.env.SLACK_NOTIFY = 'false';
+  process.env.AUTHORIZED_TEAM = 'emergency-team'
+
+  const mock = nock("https://api.github.com")
+    // mock self-introspection — the detected bot login differs from the sender
+    .get("/app").reply(200, { slug: "emergency-pr" })
+    // mock the membership check returning 404 — the bot is not on the team
+    .get(`/orgs/robandpdx/teams/emergency-team/memberships/dependabot[bot]?org=robandpdx&team_slug=emergency-team&username=dependabot%5Bbot%5D`)
+      .reply(404);
+
+  // mock the unauthorized comment
+  mock.post("/repos/robandpdx/superbigmono/issues/1/comments",
+    (requestBody) => {
+      assert.equal(requestBody.body, "@dependabot[bot] is not authorized to apply the emergency label.");
+      return true;
+    }
+  ).reply(200);
+
+  // mock the label removal
+  mock.delete("/repos/robandpdx/superbigmono/issues/1/labels/emergency",
+    (requestBody) => {
+      return true;
+    }
+  ).reply(200);
+
+  await probot.receive(payloadPrLabeledByOtherBot);
+  assert.equal(mock.pendingMocks(), []);
+});
+
+// This test confirms that if self-introspection (GET /app) fails, the app fails
+// safe: no bots bypass authorization. The bot then has to pass the team check.
+test("recieves pull_request.labeled event from a bot when self-introspection fails, do not merge the PR", async function () {
+  process.env.APPROVE_PR = 'false';
+  process.env.CREATE_ISSUE = 'false';
+  process.env.MERGE_PR = 'true';
+  process.env.SLACK_NOTIFY = 'false';
+  process.env.AUTHORIZED_TEAM = 'emergency-team'
+
+  const mock = nock("https://api.github.com")
+    // self-introspection fails
+    .get("/app").reply(500)
+    // membership check returns 404 — the bot is not on the team
+    .get(`/orgs/robandpdx/teams/emergency-team/memberships/dependabot[bot]?org=robandpdx&team_slug=emergency-team&username=dependabot%5Bbot%5D`)
+      .reply(404);
+
+  mock.post("/repos/robandpdx/superbigmono/issues/1/comments",
+    (requestBody) => {
+      assert.equal(requestBody.body, "@dependabot[bot] is not authorized to apply the emergency label.");
+      return true;
+    }
+  ).reply(200);
+
+  mock.delete("/repos/robandpdx/superbigmono/issues/1/labels/emergency",
+    (requestBody) => {
+      return true;
+    }
+  ).reply(200);
+
+  await probot.receive(payloadPrLabeledByOtherBot);
   assert.equal(mock.pendingMocks(), []);
 });
 


### PR DESCRIPTION
This pull request strengthens the authorization logic for handling GitHub bot actions, ensuring that only this app's own bot can bypass team membership checks when applying the emergency label. It introduces a self-introspection mechanism to reliably identify the app's bot and updates both the core logic and tests to enforce this stricter policy. The changes also improve test coverage for bot-related edge cases.

**Authorization improvements:**

* Added a `getAppBotLogin` function in `src/app.js` that self-introspects to determine the app's own bot login, caching the result for efficiency. Only this bot is allowlisted to bypass team membership checks; all other bots must pass the standard team check. [[1]](diffhunk://#diff-c72a907ac323cd2f334ed0e2bd07d15ab62581c4753660c8a0d1c681b30be4b6R11-R30) [[2]](diffhunk://#diff-c72a907ac323cd2f334ed0e2bd07d15ab62581c4753660c8a0d1c681b30be4b6L293-R311) [[3]](diffhunk://#diff-c72a907ac323cd2f334ed0e2bd07d15ab62581c4753660c8a0d1c681b30be4b6L303-R329)
* Updated all event handlers to pass `getAppBotLogin` to `isAuthorized`, ensuring consistent authorization logic across different PR and issue events. [[1]](diffhunk://#diff-c72a907ac323cd2f334ed0e2bd07d15ab62581c4753660c8a0d1c681b30be4b6L221-R239) [[2]](diffhunk://#diff-c72a907ac323cd2f334ed0e2bd07d15ab62581c4753660c8a0d1c681b30be4b6L258-R276)

**Test enhancements:**

* Added new test payloads and scenarios in `test.js` to verify that:
  - Only the app's own bot can bypass authorization.
  - Other bots (e.g., `dependabot[bot]`) are correctly denied if not in the authorized team.
  - The app's bot login is cached after the first lookup, avoiding redundant API calls.
  - The system fails safe if self-introspection fails, requiring all bots to pass the team check. [[1]](diffhunk://#diff-13876b4beb64b9f156474dc78f9c923952a7ca210d4507b6b3135bbe244f8a60R88-R125) [[2]](diffhunk://#diff-13876b4beb64b9f156474dc78f9c923952a7ca210d4507b6b3135bbe244f8a60L543-R694)
* Improved test setup to ensure the emergency label fallback logic is exercised.

Inspired by [this PR](https://github.com/github/emergency-pull-request-probot-app/pull/281).