### PR TITLE
Node24

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,11 +1,11 @@
 # See here for image contents: https://github.com/microsoft/vscode-dev-containers/tree/v0.195.0/containers/javascript-node/.devcontainer/base.Dockerfile
 # [Choice] Node.js version (use -bullseye variants on local arm64/Apple Silicon): 16, 14, 12, 16-bullseye, 14-bullseye, 12-bullseye, 16-buster, 14-buster, 12-buster
-ARG VARIANT=20-bullseye
-FROM mcr.microsoft.com/vscode/devcontainers/javascript-node:0-${VARIANT}
+ARG VARIANT=24-trixie
+FROM mcr.microsoft.com/vscode/devcontainers/javascript-node:${VARIANT}
 
 # [Optional] Uncomment this section to install additional OS packages.
 RUN apt-get update && export DEBIAN_FRONTEND=noninteractive \
-     && apt-get -y install --no-install-recommends python pip
+     && apt-get -y install --no-install-recommends python3 python3-pip python-is-python3 pipx
 
 # [Optional] Uncomment if you want to install an additional version of node using nvm
 # ARG EXTRA_NODE_VERSION=10
@@ -14,17 +14,16 @@ RUN apt-get update && export DEBIAN_FRONTEND=noninteractive \
 # [Optional] Uncomment if you want to install more global node modules
 # RUN su node -c "npm install -g <your-package-list-here>"
 
-# Install Azure Functions Core Tools
-RUN curl https://packages.microsoft.com/keys/microsoft.asc | gpg --dearmor > microsoft.gpg && \
-    mv microsoft.gpg /etc/apt/trusted.gpg.d/microsoft.gpg && \
-    echo "deb [arch=amd64] https://packages.microsoft.com/repos/microsoft-debian-bullseye-prod bullseye main" > /etc/apt/sources.list.d/dotnetdev.list && \
-    apt-get update && \
-    apt-get install -y azure-functions-core-tools-4
+# Install Azure Functions Core Tools (via npm so it works on both amd64 and arm64).
+# The Microsoft apt repo only ships amd64 .deb packages, which fails on Apple Silicon.
+RUN su node -c "npm install -g azure-functions-core-tools@4 --unsafe-perm true"
 
 # Install Azurite (Azure Storage Emulator)
 RUN su node -c "npm install -g azurite"
 
 # Intall aws cli
 RUN curl "https://awscli.amazonaws.com/awscli-exe-linux-aarch64.zip" -o "awscliv2.zip" && unzip awscliv2.zip && sudo ./aws/install
-# Install sam cli
-RUN pip install aws-sam-cli
+# Install sam cli (use pipx because Debian Trixie's Python is PEP 668 externally-managed)
+RUN pipx install aws-sam-cli \
+    && pipx ensurepath \
+    && ln -s /root/.local/bin/sam /usr/local/bin/sam

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -7,7 +7,7 @@
 		// Update 'VARIANT' to pick a Node version: 16, 14, 12.
 		// Append -bullseye or -buster to pin to an OS version.
 		// Use -bullseye variants on local arm64/Apple Silicon.
-		"args": { "VARIANT": "20-bullseye" }
+		"args": { "VARIANT": "24-trixie" }
 	},
 
 	"settings": {},

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -21,7 +21,7 @@ jobs:
     - uses: actions/checkout@v6
     - uses: actions/setup-node@v6
       with:
-        node-version: 20
+        node-version: 24
         check-latest: true
         cache: npm
     - run: npm ci

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -15,7 +15,7 @@ jobs:
       - uses: actions/checkout@v6
       - uses: actions/setup-node@v6
         with:
-          node-version: 20
+          node-version: 24
           check-latest: true
           cache: npm
       - run: npm ci

--- a/src/functions/ProbotFunction.js
+++ b/src/functions/ProbotFunction.js
@@ -2,13 +2,30 @@ const { app } = require('@azure/functions');
 const {
   createAzureFunctionV4,
   createProbot,
+  ProbotOctokit,
 } = require("@probot/adapter-azure-functions");
 const probotapp = require("../app");
+
+// Pin the GitHub REST API version on every request so we don't fall back to
+// the default (2022-11-28), which is scheduled to be retired on 2028-03-10
+// and triggers `[@octokit/request] ... is deprecated` warnings on every call.
+const PinnedApiVersionOctokit = ProbotOctokit.defaults({
+  userAgent: "emergency-pull-request-probot-azure",
+  request: {
+    headers: {
+      "X-GitHub-Api-Version": "2026-03-10",
+    },
+  },
+});
 
 app.http('ProbotFunction', {
     methods: ['POST'],
     authLevel: 'anonymous',
     handler: createAzureFunctionV4(probotapp, {
-      probot: createProbot(),
+      probot: createProbot({
+        overrides: {
+          Octokit: PinnedApiVersionOctokit,
+        },
+      }),
     }),
 });

--- a/test.js
+++ b/test.js
@@ -328,6 +328,11 @@ test.before.each(() => {
     Octokit: ProbotOctokit.defaults({
       throttle: { enabled: false },
       retry: { enabled: false },
+      request: {
+        headers: {
+          "X-GitHub-Api-Version": "2026-03-10",
+        },
+      },
     }),
   });
   probot.load(app);


### PR DESCRIPTION
This pull request upgrades the project to Node.js 24 and Debian Trixie across development, CI, and devcontainer environments. It also updates the installation methods for several dependencies to improve compatibility with Apple Silicon and future-proofs GitHub API usage by pinning the REST API version in all requests.

**Platform and Dependency Upgrades:**

* Upgraded the Node.js version from 20 to 24 in GitHub Actions workflows (`.github/workflows/pr.yml`, `.github/workflows/test.yml`), devcontainer configuration (`.devcontainer/Dockerfile`, `.devcontainer/devcontainer.json`), and base Docker image to use Debian Trixie for better compatibility and support. [[1]](diffhunk://#diff-15c806aa509538190832852f439e9921a23bec2da81f95ed0e4bf13c14e5b160L24-R24) [[2]](diffhunk://#diff-faff1af3d8ff408964a57b2e475f69a6b7c7b71c9978cccc8f471798caac2c88L18-R18) [[3]](diffhunk://#diff-13bd9d7a30bf46656bc81f1ad5b908a627f9247be3f7d76df862b0578b534fc6L3-R8) [[4]](diffhunk://#diff-24ad71c8613ddcf6fd23818cb3bb477a1fb6d83af4550b0bad43099813088686L10-R10)

* Changed the installation of Azure Functions Core Tools from using the Microsoft apt repository (which only supports amd64) to using npm, ensuring compatibility with both amd64 and arm64 (Apple Silicon) systems.

* Updated the installation of `aws-sam-cli` to use `pipx` due to Python packaging changes in Debian Trixie (PEP 668), and ensured the CLI is available on the system path.

**API Usage Improvements:**

* Modified the Probot Azure Functions adapter (`src/functions/ProbotFunction.js`) to pin the GitHub REST API version (`2026-03-10`) on all requests, preventing deprecation warnings and ensuring future compatibility.

* Updated tests to also pin the GitHub REST API version in the test Octokit instance, matching production behavior and avoiding deprecation warnings during testing.